### PR TITLE
Update appengine-web.xml with the correct project

### DIFF
--- a/Fit/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/Fit/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>mmutuma-sps-spring20</application>
+  <application>team10-sps-spring20</application>
   <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>


### PR DESCRIPTION
I just created a new GCP (Google Cloud Platform) project for the product sprint, so you should start using that project for the web site you all are developing, instead of Murori's.

Whoever approves the second time, feel free to merge/close this PR (it's an exercise). Some convention is to let the original PR request merge/close any approved PR, so if you'd like to adopt that convention, that's totally fine and just let everyone know by stating your preference in your review.